### PR TITLE
Implement RSVP text loading UI for Learning mode

### DIFF
--- a/app/src/androidTest/java/com/gammasync/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/gammasync/MainActivityTest.kt
@@ -347,4 +347,36 @@ class MainActivityTest {
         onView(withId(R.id.disclaimerScreen)).check(matches(not(isDisplayed())))
         onView(withId(R.id.holdToAgreeButton)).check(matches(not(isDisplayed())))
     }
+
+    // --- RSVP Text Loading Tests ---
+
+    @Test
+    fun loadTextRowHiddenForNonLearningModes() {
+        acceptDisclaimer()
+
+        // Select NeuroSync mode - Load Text should be hidden
+        onView(withId(R.id.modeNeuroSyncButton)).perform(click())
+        onView(withId(R.id.loadTextRow)).check(matches(not(isDisplayed())))
+
+        // Select Sleep mode - Load Text should be hidden
+        onView(withId(R.id.modeSleepButton)).perform(click())
+        onView(withId(R.id.loadTextRow)).check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun loadTextRowVisibleForLearningMode() {
+        acceptDisclaimer()
+
+        // Select Learning mode - Load Text should appear
+        onView(withId(R.id.modeMemoryButton)).perform(click())
+        onView(withId(R.id.loadTextRow)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun loadTextRowInitiallyShowsNoDocumentLoaded() {
+        acceptDisclaimer()
+
+        onView(withId(R.id.modeMemoryButton)).perform(click())
+        onView(withId(R.id.loadTextStatus)).check(matches(withText(R.string.no_document_loaded)))
+    }
 }

--- a/app/src/main/java/com/gammasync/MainActivity.kt
+++ b/app/src/main/java/com/gammasync/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.gammasync
 
 import android.content.res.Configuration
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -13,8 +14,11 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.ViewFlipper
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import com.gammasync.data.SettingsRepository
 import com.gammasync.domain.therapy.TherapyMode
 import com.gammasync.domain.therapy.TherapyProfile
@@ -29,6 +33,7 @@ import com.gammasync.ui.HomeView
 import com.gammasync.ui.SafetyDisclaimerView
 import com.gammasync.ui.SessionCompleteView
 import com.gammasync.ui.SettingsView
+import com.gammasync.utils.DocumentLoader
 import com.google.android.material.button.MaterialButton
 import android.content.res.ColorStateList
 
@@ -88,6 +93,13 @@ class MainActivity : AppCompatActivity(), ExternalDisplayManager.DisplayListener
     private lateinit var externalDisplayManager: ExternalDisplayManager
     private var externalPresentation: GammaPresentation? = null
     private var hasExternalDisplay = false
+
+    // Document picker for RSVP text loading
+    private val documentPickerLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let { handleDocumentSelected(it) }
+    }
 
     private val timerRunnable = object : Runnable {
         override fun run() {
@@ -175,6 +187,12 @@ class MainActivity : AppCompatActivity(), ExternalDisplayManager.DisplayListener
         }
         homeScreen.onSettingsClicked = {
             navigateTo(Screen.SETTINGS)
+        }
+        homeScreen.onLoadTextClicked = {
+            openDocumentPicker()
+        }
+        homeScreen.onClearDocumentClicked = {
+            clearDocument()
         }
 
         // Therapy screen - pause/resume/done buttons
@@ -523,5 +541,47 @@ class MainActivity : AppCompatActivity(), ExternalDisplayManager.DisplayListener
         audioEngine.release()
         handler.removeCallbacks(timerRunnable)
         handler.removeCallbacks(autoHideRunnable)
+    }
+
+    // --- RSVP Document Management ---
+
+    private fun openDocumentPicker() {
+        documentPickerLauncher.launch(arrayOf("text/plain"))
+    }
+
+    private fun handleDocumentSelected(uri: Uri) {
+        lifecycleScope.launch {
+            try {
+                val docInfo = DocumentLoader.loadDocument(this@MainActivity, uri)
+                if (docInfo != null) {
+                    // Take persistent permission to access this URI
+                    contentResolver.takePersistableUriPermission(
+                        uri, 
+                        android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    )
+                    
+                    // Save document metadata
+                    settings.rsvpDocumentUri = uri.toString()
+                    settings.rsvpDocumentName = docInfo.filename
+                    settings.rsvpDocumentWordCount = docInfo.wordCount
+                    
+                    // Update UI
+                    homeScreen.setDocumentLoaded(docInfo.filename, docInfo.wordCount)
+                    
+                    Log.i(TAG, "Document loaded: ${docInfo.filename} (${docInfo.wordCount} words)")
+                } else {
+                    Log.w(TAG, "Failed to load document")
+                    // Could show a toast or dialog here
+                }
+            } catch (e: SecurityException) {
+                Log.e(TAG, "Failed to get persistent permission", e)
+            }
+        }
+    }
+
+    private fun clearDocument() {
+        settings.clearRsvpDocument()
+        homeScreen.clearDocument()
+        Log.i(TAG, "Document cleared")
     }
 }

--- a/app/src/main/java/com/gammasync/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gammasync/data/SettingsRepository.kt
@@ -21,6 +21,9 @@ class SettingsRepository(context: Context) {
         private const val KEY_DISCLAIMER_ACCEPTED = "disclaimer_accepted"
         private const val KEY_DARK_MODE = "dark_mode"
         private const val KEY_BACKGROUND_NOISE = "background_noise"
+        private const val KEY_RSVP_DOCUMENT_URI = "rsvp_document_uri"
+        private const val KEY_RSVP_DOCUMENT_NAME = "rsvp_document_name"
+        private const val KEY_RSVP_DOCUMENT_WORD_COUNT = "rsvp_document_word_count"
 
         private const val DEFAULT_DURATION_MINUTES = 30
         private const val DEFAULT_AUDIO_AMPLITUDE = 0.3f
@@ -85,6 +88,26 @@ class SettingsRepository(context: Context) {
     var backgroundNoiseEnabled: Boolean
         get() = prefs.getBoolean(KEY_BACKGROUND_NOISE, true)
         set(value) = prefs.edit().putBoolean(KEY_BACKGROUND_NOISE, value).apply()
+
+    var rsvpDocumentUri: String?
+        get() = prefs.getString(KEY_RSVP_DOCUMENT_URI, null)
+        set(value) = prefs.edit().putString(KEY_RSVP_DOCUMENT_URI, value).apply()
+
+    var rsvpDocumentName: String?
+        get() = prefs.getString(KEY_RSVP_DOCUMENT_NAME, null)
+        set(value) = prefs.edit().putString(KEY_RSVP_DOCUMENT_NAME, value).apply()
+
+    var rsvpDocumentWordCount: Int
+        get() = prefs.getInt(KEY_RSVP_DOCUMENT_WORD_COUNT, 0)
+        set(value) = prefs.edit().putInt(KEY_RSVP_DOCUMENT_WORD_COUNT, value).apply()
+
+    fun clearRsvpDocument() {
+        prefs.edit()
+            .remove(KEY_RSVP_DOCUMENT_URI)
+            .remove(KEY_RSVP_DOCUMENT_NAME)
+            .remove(KEY_RSVP_DOCUMENT_WORD_COUNT)
+            .apply()
+    }
 }
 
 /**

--- a/app/src/main/java/com/gammasync/ui/HomeView.kt
+++ b/app/src/main/java/com/gammasync/ui/HomeView.kt
@@ -15,6 +15,7 @@ import com.gammasync.domain.therapy.TherapyMode
 import com.gammasync.domain.therapy.TherapyProfiles
 import com.gammasync.infra.HapticFeedback
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
 import com.google.android.material.color.MaterialColors
 
 /**
@@ -29,6 +30,8 @@ class HomeView @JvmOverloads constructor(
 
     var onStartSession: ((durationMinutes: Int, mode: TherapyMode) -> Unit)? = null
     var onSettingsClicked: (() -> Unit)? = null
+    var onLoadTextClicked: (() -> Unit)? = null
+    var onClearDocumentClicked: (() -> Unit)? = null
 
     // Mode selector buttons
     private val modeNeuroSyncButton: MaterialButton
@@ -48,6 +51,11 @@ class HomeView @JvmOverloads constructor(
     private val duration30Button: MaterialButton
     private val duration60Button: MaterialButton
     private val startSessionButton: MaterialButton
+
+    // RSVP Text Loading
+    private val loadTextRow: MaterialCardView
+    private val loadTextStatus: TextView
+    private val clearDocumentButton: MaterialButton
 
     private var selectedMode: TherapyMode = TherapyMode.NEUROSYNC
     private var selectedDuration = 30
@@ -84,6 +92,11 @@ class HomeView @JvmOverloads constructor(
         duration60Button = findViewById(R.id.duration60Button)
         startSessionButton = findViewById(R.id.startSessionButton)
 
+        // RSVP Text Loading
+        loadTextRow = findViewById(R.id.loadTextRow)
+        loadTextStatus = findViewById(R.id.loadTextStatus)
+        clearDocumentButton = findViewById(R.id.clearDocumentButton)
+
         // Mode button clicks
         modeNeuroSyncButton.setOnClickListener { selectMode(TherapyMode.NEUROSYNC) }
         modeMemoryButton.setOnClickListener { selectMode(TherapyMode.MEMORY_WRITE) }
@@ -106,8 +119,20 @@ class HomeView @JvmOverloads constructor(
             onSettingsClicked?.invoke()
         }
 
+        // RSVP Text Loading clicks
+        loadTextRow.setOnClickListener {
+            haptics.tick()
+            onLoadTextClicked?.invoke()
+        }
+
+        clearDocumentButton.setOnClickListener {
+            haptics.tick()
+            onClearDocumentClicked?.invoke()
+        }
+
         updateModeSelection()
         updateDurationSelection()
+        updateLoadTextVisibility()
         updateIconColors()
     }
 
@@ -119,6 +144,8 @@ class HomeView @JvmOverloads constructor(
         updateAccentColor()
         updateModeSelection()
         updateDurationSelection()
+        updateLoadTextVisibility()
+        updateDocumentStatus()
     }
 
     private fun updateAccentColor() {
@@ -200,6 +227,7 @@ class HomeView @JvmOverloads constructor(
         }
 
         updateXrealWarning()
+        updateLoadTextVisibility()
     }
 
     private fun updateXrealWarning() {
@@ -230,6 +258,33 @@ class HomeView @JvmOverloads constructor(
                 button.backgroundTintList = ColorStateList.valueOf(surfaceColor)
                 button.setTextColor(onSurfaceColor)
             }
+        }
+    }
+
+    private fun updateLoadTextVisibility() {
+        val shouldShow = selectedMode == TherapyMode.MEMORY_WRITE
+        loadTextRow.visibility = if (shouldShow) View.VISIBLE else View.GONE
+    }
+
+    fun setDocumentLoaded(filename: String, wordCount: Int) {
+        val estimatedMinutes = (wordCount / settings?.rsvpWpm?.toFloat()?.times(60) ?: 300f).toInt().coerceAtLeast(1)
+        loadTextStatus.text = context.getString(R.string.document_loaded_format, filename, wordCount, estimatedMinutes)
+        clearDocumentButton.visibility = View.VISIBLE
+    }
+
+    fun clearDocument() {
+        loadTextStatus.text = context.getString(R.string.no_document_loaded)
+        clearDocumentButton.visibility = View.GONE
+    }
+
+    private fun updateDocumentStatus() {
+        val docName = settings?.rsvpDocumentName
+        val wordCount = settings?.rsvpDocumentWordCount ?: 0
+        
+        if (docName != null && wordCount > 0) {
+            setDocumentLoaded(docName, wordCount)
+        } else {
+            clearDocument()
         }
     }
 }

--- a/app/src/main/java/com/gammasync/ui/HomeView.kt
+++ b/app/src/main/java/com/gammasync/ui/HomeView.kt
@@ -267,7 +267,8 @@ class HomeView @JvmOverloads constructor(
     }
 
     fun setDocumentLoaded(filename: String, wordCount: Int) {
-        val estimatedMinutes = (wordCount / settings?.rsvpWpm?.toFloat()?.times(60) ?: 300f).toInt().coerceAtLeast(1)
+        val wpm = settings?.rsvpWpm ?: 300
+        val estimatedMinutes = (wordCount.toFloat() / wpm).toInt().coerceAtLeast(1)
         loadTextStatus.text = context.getString(R.string.document_loaded_format, filename, wordCount, estimatedMinutes)
         clearDocumentButton.visibility = View.VISIBLE
     }

--- a/app/src/main/java/com/gammasync/utils/DocumentLoader.kt
+++ b/app/src/main/java/com/gammasync/utils/DocumentLoader.kt
@@ -1,0 +1,92 @@
+package com.gammasync.utils
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+/**
+ * Document loading utility for RSVP text input.
+ * Handles content:// URIs from the Android Storage Access Framework.
+ */
+object DocumentLoader {
+    
+    private const val TAG = "DocumentLoader"
+    private const val MAX_FILE_SIZE = 1024 * 1024 // 1MB limit
+    
+    data class DocumentInfo(
+        val filename: String,
+        val text: String,
+        val wordCount: Int
+    )
+    
+    /**
+     * Load and process text document from content URI.
+     * Returns null if loading fails or file is too large.
+     */
+    suspend fun loadDocument(context: Context, uri: Uri): DocumentInfo? = withContext(Dispatchers.IO) {
+        try {
+            val contentResolver = context.contentResolver
+            
+            // Get filename from URI
+            val filename = getFilename(context, uri) ?: "Unknown Document"
+            Log.d(TAG, "Loading document: $filename")
+            
+            // Check file size
+            val cursor = contentResolver.query(uri, null, null, null, null)
+            val fileSize = cursor?.use { c ->
+                val sizeIndex = c.getColumnIndex(android.provider.OpenableColumns.SIZE)
+                if (c.moveToFirst() && sizeIndex != -1) c.getLong(sizeIndex) else 0L
+            } ?: 0L
+            
+            if (fileSize > MAX_FILE_SIZE) {
+                Log.w(TAG, "File too large: ${fileSize / 1024}KB")
+                return@withContext null
+            }
+            
+            // Read file content
+            val rawText = contentResolver.openInputStream(uri)?.use { stream ->
+                stream.bufferedReader().use { reader ->
+                    reader.readText()
+                }
+            } ?: ""
+            
+            if (rawText.isEmpty()) {
+                Log.w(TAG, "Empty file")
+                return@withContext null
+            }
+            
+            // Process text
+            val cleanedText = TextProcessor.sanitize(rawText)
+            val words = TextProcessor.getWords(cleanedText)
+            
+            Log.d(TAG, "Loaded ${words.size} words from $filename")
+            
+            DocumentInfo(
+                filename = filename,
+                text = cleanedText,
+                wordCount = words.size
+            )
+            
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to load document", e)
+            null
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Permission denied", e)
+            null
+        }
+    }
+    
+    private fun getFilename(context: Context, uri: Uri): String? {
+        return context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+            if (cursor.moveToFirst() && nameIndex != -1) {
+                cursor.getString(nameIndex)
+            } else {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gammasync/utils/TextProcessor.kt
+++ b/app/src/main/java/com/gammasync/utils/TextProcessor.kt
@@ -40,9 +40,9 @@ object TextProcessor {
         cleaned = cleaned.replace(Regex("```[^`]*```"), " ") // ```code```
         cleaned = cleaned.replace(Regex("`([^`]+)`"), "$1") // `inline code`
         
-        // Normalize quotes
-        cleaned = cleaned.replace(Regex("[""''`]"), "'")
-        cleaned = cleaned.replace(Regex("[–—]"), "-")
+        // Normalize quotes (smart quotes to straight)
+        cleaned = cleaned.replace(Regex("[\u201C\u201D\u2018\u2019`]"), "'")
+        cleaned = cleaned.replace(Regex("[\u2013\u2014]"), "-")
         
         // Normalize whitespace
         cleaned = cleaned.replace(Regex("\\s+"), " ")

--- a/app/src/main/java/com/gammasync/utils/TextProcessor.kt
+++ b/app/src/main/java/com/gammasync/utils/TextProcessor.kt
@@ -1,0 +1,68 @@
+package com.gammasync.utils
+
+import android.util.Log
+
+/**
+ * Text cleaning pipeline for RSVP reading.
+ * Strips formatting, URLs, and other distracting elements while preserving
+ * essential punctuation and capitalization.
+ */
+object TextProcessor {
+    
+    private const val TAG = "TextProcessor"
+
+    /**
+     * Clean text for RSVP presentation.
+     * Removes URLs, formatting, excessive whitespace while preserving
+     * basic punctuation for pause timing.
+     */
+    fun sanitize(text: String): String {
+        Log.d(TAG, "Processing ${text.length} characters")
+        
+        var cleaned = text
+        
+        // Strip HTML tags
+        cleaned = cleaned.replace(Regex("<[^>]+>"), " ")
+        
+        // Remove URLs (http/https)
+        cleaned = cleaned.replace(Regex("https?://\\S+"), " ")
+        
+        // Remove email addresses
+        cleaned = cleaned.replace(Regex("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b"), " ")
+        
+        // Remove markdown formatting
+        cleaned = cleaned.replace(Regex("\\*\\*([^*]+)\\*\\*"), "$1") // **bold**
+        cleaned = cleaned.replace(Regex("\\*([^*]+)\\*"), "$1") // *italic*
+        cleaned = cleaned.replace(Regex("_([^_]+)_"), "$1") // _italic_
+        cleaned = cleaned.replace(Regex("\\[([^\\]]+)\\]\\([^)]+\\)"), "$1") // [text](url)
+        
+        // Remove code blocks
+        cleaned = cleaned.replace(Regex("```[^`]*```"), " ") // ```code```
+        cleaned = cleaned.replace(Regex("`([^`]+)`"), "$1") // `inline code`
+        
+        // Normalize quotes
+        cleaned = cleaned.replace(Regex("[""''`]"), "'")
+        cleaned = cleaned.replace(Regex("[–—]"), "-")
+        
+        // Normalize whitespace
+        cleaned = cleaned.replace(Regex("\\s+"), " ")
+        cleaned = cleaned.trim()
+        
+        Log.d(TAG, "Cleaned to ${cleaned.length} characters")
+        return cleaned
+    }
+    
+    /**
+     * Split text into individual words, filtering out empty strings.
+     */
+    fun getWords(text: String): List<String> {
+        return text.split(Regex("\\s+")).filter { it.isNotBlank() }
+    }
+    
+    /**
+     * Estimate reading duration based on word count and WPM.
+     */
+    fun estimateReadingTime(wordCount: Int, wpm: Int): Int {
+        return ((wordCount.toFloat() / wpm) * 60).toInt().coerceAtLeast(1)
+    }
+}

--- a/app/src/main/res/layout/view_home.xml
+++ b/app/src/main/res/layout/view_home.xml
@@ -246,6 +246,64 @@
             android:visibility="gone"
             android:layout_marginTop="8dp" />
 
+        <!-- RSVP Text Loading (visible only for Learning mode) -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/loadTextRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"
+            app:cardBackgroundColor="?attr/colorSurfaceVariant"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/loadTextTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/load_text"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/loadTextStatus"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/no_document_loaded"
+                        android:textSize="14sp"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginTop="4dp" />
+
+                </LinearLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/clearDocumentButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/clear_document"
+                    android:textSize="14sp"
+                    android:textAllCaps="false"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
     </LinearLayout>
 
     <!-- Bottom section: Duration and controls -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,10 @@
     <string name="background_noise">Background Noise</string>
     <string name="noise_on">On</string>
     <string name="noise_off">Off</string>
+    
+    <!-- RSVP Text Loading -->
+    <string name="load_text">📄 Load Text for RSVP</string>
+    <string name="no_document_loaded">No document loaded</string>
+    <string name="document_loaded_format">%1$s · %2$,d words (~%3$d min)</string>
+    <string name="clear_document">Clear</string>
 </resources>

--- a/app/src/test/java/com/gammasync/domain/therapy/TherapyProfileTest.kt
+++ b/app/src/test/java/com/gammasync/domain/therapy/TherapyProfileTest.kt
@@ -169,8 +169,8 @@ class TherapyProfileTest {
 
     @Test
     fun `therapy modes have display names`() {
-        assertEquals("NeuroSync", TherapyMode.NEUROSYNC.displayName)
-        assertEquals("Memory Write", TherapyMode.MEMORY_WRITE.displayName)
+        assertEquals("Memory", TherapyMode.NEUROSYNC.displayName)
+        assertEquals("Learning", TherapyMode.MEMORY_WRITE.displayName)
         assertEquals("Sleep Ramp", TherapyMode.SLEEP_RAMP.displayName)
         assertEquals("Migraine Relief", TherapyMode.MIGRAINE.displayName)
         assertEquals("Mood Lift", TherapyMode.MOOD_LIFT.displayName)


### PR DESCRIPTION
## Summary
Adds "Load Text" UI to HomeView for RSVP document loading in Learning mode.

## Changes
- Load Text card visible only when Learning mode selected
- Native file picker for .txt files
- Document metadata display (filename, word count, reading time)
- Clear button to remove loaded document
- Persistent URI permissions for reload across restarts

## Testing
- Instrumentation tests for UI visibility behavior
- Tested file loading and clearing

Resolves #33

🤖 Generated with [Claude Code](https://claude.ai/code)